### PR TITLE
G2L-222 startdate and enddate for module

### DIFF
--- a/LMS.API/Data/SeedData.cs
+++ b/LMS.API/Data/SeedData.cs
@@ -81,12 +81,38 @@ namespace LMS.API.Data
 
         private static List<Module> GenerateModules(int count, List<Course> courses)
         {
+            var modules = new List<Module>();
             var faker = new Faker<Module>()
                 .RuleFor(m => m.Name, f => f.Lorem.Word())
-                .RuleFor(m => m.Description, f => f.Lorem.Sentence())
-                .RuleFor(m => m.CourseId, f => f.PickRandom(courses).Id);
+                .RuleFor(m => m.Description, f => f.Lorem.Sentence());
 
-            return faker.Generate(count);
+            Random random = new Random();
+
+            foreach (var course in courses)
+            {
+                DateTime currentStartDate = course.StartDate;
+
+                for (int i = 0; i < count; i++)
+                {
+                    
+                    int moduleDurationInDays = random.Next(7, 28); // Each module lasts between 1 and 4 weeks
+
+                    var module = faker
+                        .RuleFor(m => m.CourseId, _ => course.Id)
+                        .RuleFor(m => m.StartDate, _ => currentStartDate)
+                        .RuleFor(m => m.EndDate, _ =>
+                        {
+                            var endDate = currentStartDate.AddDays(moduleDurationInDays);
+                            currentStartDate = endDate.AddDays(1); // The next module starts the day after the previous one
+                            return endDate;
+                        })
+                        .Generate();
+
+                    modules.Add(module);
+                }
+            }
+
+            return modules;
         }
 
         private static List<ActivityType> GenerateActivityTypes(int count)

--- a/LMS.API/LMS.API.csproj
+++ b/LMS.API/LMS.API.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Migrations\" />
+  </ItemGroup>
+
 </Project>

--- a/LMS.API/Models/Dtos/ModuleDto.cs
+++ b/LMS.API/Models/Dtos/ModuleDto.cs
@@ -5,6 +5,8 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
         public int CourseId { get; set; }
         //public CourseDto Course { get; set; }
         public IEnumerable<ActivityDto> Activities { get; set; }

--- a/LMS.API/Models/Entities/Module.cs
+++ b/LMS.API/Models/Entities/Module.cs
@@ -8,6 +8,8 @@ namespace LMS.API.Models.Entities
         [Required]
         public string Name { get; set; }
         public string? Description { get; set; }
+        public DateTime StartDate { get; set; } 
+        public DateTime EndDate { get; set; }
         [Required]
         public int CourseId { get; set; }
         public Course? Course { get; set; }


### PR DESCRIPTION
# Add StartDate and EndDate to each Module in SeedData

| Status  | Type  | Env Vars Change | Review App | Ticket |
| :---: | :---: | :---: | :--: | :--: |
| Hold | Story | No | No | [G2L-222](https://grupp2ltu.atlassian.net/jira/software/projects/G2L/boards/1/backlog?epics=visible&selectedIssue=G2L-222) |

> ⚠️ **1. New Fields in Module:**
> - **StartDate** and **EndDate** have been added to the **Module** entity.
> - This means that all modules must now have a start and end date when they are created.

> ⚠️ **2. Data Logic Requirements:**
> - **Start and end dates for modules** follow specific logic, where each module starts after the previous one and has a >random duration (e.g., 1 to 4 weeks) to simulate different lengths.
> - Modules must not overlap with each other or have start and end dates that exceed the course's timeframe (in cases >where a course has an end date).


## Problem

Modules from seed data don't have Startdate or EndDate.


## Solution

- Add Startdate and EndDate for each Module.
- Make it possible for frontend to get Startdate and EndDate from endpoint response.


## After Screenshots



**AFTER**:
![image](https://github.com/user-attachments/assets/55daae19-4ae3-4a17-af77-d1a3b3b9a1ae)
![image](https://github.com/user-attachments/assets/bbc14c87-8574-4539-b4a7-6d801ee2db43)






